### PR TITLE
LtExp Expression Correction and New Tests for LtExp

### DIFF
--- a/oberon/src/main/scala/br/unb/cic/oberon/Expression.scala
+++ b/oberon/src/main/scala/br/unb/cic/oberon/Expression.scala
@@ -91,7 +91,7 @@ case class LtExp(val lhs: Expression, val rhs: Expression) extends Expression {
     if(l.computeType() == TInt() && r.computeType() == TInt()) {
       return new BoolValue(l.asInstanceOf[IntValue].value < r.asInstanceOf[IntValue].value)
     }
-    return new BoolValue(l.asInstanceOf[IntValue].value < r.asInstanceOf[IntValue].value)
+    throw new RuntimeException("cant compare " + lhs.computeType() + " with " + rhs.computeType())
   }
 
   def accept(v : Visitor) {

--- a/oberon/src/test/scala/br/unb/cic/oberon/ExpressionTest.scala
+++ b/oberon/src/test/scala/br/unb/cic/oberon/ExpressionTest.scala
@@ -29,6 +29,30 @@ class ExpressionTest extends FunSuite {
     assert(int7 == sum.eval())
   }
 
+  test("Evaluating a LtExp(3, 4) should lead to an BoolValue(true)") {
+    val t = new IntValue(3)
+    val i = new IntValue(4)
+    val bool = new BoolValue(true)
+
+    val less = LtExp(t, i)
+
+    assert(t.typeCheck())
+    assert(i.typeCheck())
+    assert(less.eval() == bool)
+  }
+
+  test("Evaluating a LtExp(4, 3) should lead to an BoolValue(false)") {
+    val t = new IntValue(4)
+    val i = new IntValue(3)
+    val bool = new BoolValue(false)
+
+    val less = LtExp(t, i)
+
+    assert(t.typeCheck())
+    assert(i.typeCheck())
+    assert(less.eval() == bool)
+  }
+
   test("The Expression Add(true, 3) should be invalid") {
     val t = new BoolValue(true)
     val i = new IntValue(3)
@@ -51,6 +75,20 @@ class ExpressionTest extends FunSuite {
     assert(i.typeCheck())
     assert(and.computeType == TError())
     assert(!and.typeCheck())
+  }
+
+  test("The expression Lt(true, 3) should be invalid") {
+    val t = new BoolValue(true)
+    val i = new IntValue(3)
+
+    val less = LtExp(t, i)
+
+    assert(t.typeCheck())
+    assert(i.typeCheck())
+
+    assertThrows[java.lang.RuntimeException] {
+      less.eval()
+    }
   }
 }
 


### PR DESCRIPTION
I noticed the return duplication in the LtExp Expression Eval () Method and am sending a correction that throws an exception when there is a comparison of two variables of different types, such as:
 true < 5.

When trying to make this kind of comparison, it was giving error of
**java.lang.ClassCastException: br.unb.cic.oberon.BoolValue cannot be cast to br.unb.cic.oberon.IntValue**

Whose I believe is the wrong exception for the occasion.

This is it. Thanks.